### PR TITLE
dgaintel/predict.py: fix get_prediction with a list

### DIFF
--- a/dgaintel/predict.py
+++ b/dgaintel/predict.py
@@ -81,7 +81,10 @@ def get_prediction(domains, to_file=None, show=True):
         show=False: list of prediction strings (list)
         to_file=<filename>.txt: writes new file at <filename>.txt with predictions
     '''
-    raw_probs = get_prob(_inputs(domains), internal=True)
+    if not isinstance(domains, list):
+        domains = _inputs(domains)
+
+    raw_probs = get_prob(domains, internal=True)
     preds = [_get_prediction(domain, prob=prob) for domain, prob in raw_probs]
 
     if to_file:


### PR DESCRIPTION
Fix the following error:

```
>>> dgaintel.get_prediction(['microsoft.com', 'wikipedia.com', 'vlurgpeddygdy.com'])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/pi/.local/lib/python3.7/site-packages/dgaintel/predict.py", line 84, in get_prediction
    raw_probs = get_prob(_inputs(domains), internal=True)
  File "/home/pi/.local/lib/python3.7/site-packages/dgaintel/predict.py", line 21, in _inputs
    lpath = os.path.splitext(domains)
  File "/usr/lib/python3.7/posixpath.py", line 122, in splitext
    p = os.fspath(p)
TypeError: expected str, bytes or os.PathLike object, not list
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>